### PR TITLE
Add settings to apply paranoid only to specific build types

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ paranoid {
 ```
 
 The extension object contains the following properties:
-- `enabled` — `boolean`. Allows to disable obfuscation for the project. Default value is `true`.
 - `cacheable` — `boolean`. Allows to enable caching for the transform. Default value is `false`.
 - `includeSubprojects` — `boolean`. Allows to enable obfuscation for subprojects. Default value is `false`.
 - `obfuscationSeed` - `Integer`. A seed that can be used to make obfuscation stable across builds. Default value is `null`, which means that the seed
   is computed from input files on each build.
+- `applyToBuildTypes` - Allows to apply paranoid transform for specific build types. Possible values are `'ALL'`, `'NONE'`, `'NOT_DEBUGGABLE'`. Default value is `'ALL'`
+- `enabled` — `boolean`. Allows to disable obfuscation for the project. Default value is `true`. *Deprecated*. Use `applyToBuildTypes = 'NONE'`
 
 How it works
 ------------

--- a/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidExtension.kt
+++ b/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidExtension.kt
@@ -18,10 +18,26 @@ package com.joom.paranoid.plugin
 
 import java.io.File
 
+import com.joom.paranoid.processor.logging.getLogger
+
 open class ParanoidExtension {
+  @Deprecated(IS_ENABLED_DEPRECATION_WARNING)
   var isEnabled: Boolean = true
+    set(value) {
+      getLogger().warn("WARNING: $IS_ENABLED_DEPRECATION_WARNING")
+      field = value
+    }
   var isCacheable: Boolean = false
   var includeSubprojects: Boolean = false
   var obfuscationSeed: Int? = null
   var bootClasspath: List<File> = emptyList()
+  var applyToBuildTypes: BuildType = BuildType.ALL
 }
+
+enum class BuildType {
+  NONE,
+  ALL,
+  NOT_DEBUGGABLE
+}
+
+private const val IS_ENABLED_DEPRECATION_WARNING = "paranoid.enabled is deprecated. Use paranoid.applyToBuildTypes"

--- a/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidTransform.kt
+++ b/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidTransform.kt
@@ -24,6 +24,7 @@ import com.android.build.api.transform.Transform
 import com.android.build.api.transform.TransformException
 import com.android.build.api.transform.TransformInvocation
 import com.android.build.api.transform.TransformOutputProvider
+import com.android.build.api.variant.VariantInfo
 import com.joom.paranoid.processor.ParanoidProcessor
 import java.io.File
 import java.security.SecureRandom
@@ -47,11 +48,6 @@ class ParanoidTransform(
         input.scopes,
         format
       )
-    }
-
-    if (!paranoid.isEnabled) {
-      copyInputsToOutputs(inputs.map { it.file }, outputs)
-      return
     }
 
     val processor = ParanoidProcessor(
@@ -114,12 +110,25 @@ class ParanoidTransform(
     return paranoid.isCacheable
   }
 
+  override fun applyToVariant(variant: VariantInfo): Boolean {
+    if (!paranoid.isEnabled) {
+      return false
+    }
+
+    return when (paranoid.applyToBuildTypes) {
+      BuildType.NONE -> false
+      BuildType.ALL -> true
+      BuildType.NOT_DEBUGGABLE -> !variant.isDebuggable
+    }
+  }
+
   override fun getParameterInputs(): MutableMap<String, Any?> {
     return mutableMapOf(
       "version" to Build.VERSION,
       "enabled" to paranoid.isEnabled,
       "includeSubprojects" to paranoid.includeSubprojects,
-      "obfuscationSeed" to paranoid.obfuscationSeed
+      "obfuscationSeed" to paranoid.obfuscationSeed,
+      "applyToBuildTypes" to paranoid.applyToBuildTypes
     )
   }
 

--- a/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidTransform.kt
+++ b/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidTransform.kt
@@ -115,6 +115,10 @@ class ParanoidTransform(
       return false
     }
 
+    if (variant.isTest) {
+      return false
+    }
+
     return when (paranoid.applyToBuildTypes) {
       BuildType.NONE -> false
       BuildType.ALL -> true


### PR DESCRIPTION
Added config param `applyToBuildTypes` to switch off transform for specific build types.
Possible values are: 
ALL - add transforms for all build types
NOT_DEBBUGABLE - add transforms only for build types with debuggable = false (release build type in most cases)
NONE - Do not add transforms at all. 

`applyToBuildTypes = 'NONE'` works exactly as `enabled = false`

Added deprecation warning to build log if `enabled` is used. 