### PR TITLE
Fix duplicated asm in paranoid-gradle-plugin shadow jar

### DIFF
--- a/paranoid/pablo.gradle
+++ b/paranoid/pablo.gradle
@@ -1,6 +1,11 @@
 apply plugin: 'io.michaelrocks.pablo'
 
+def shadowEnabled = project.providers.gradleProperty("pablo.shadow.enabled").map { it.toBoolean() }
 configurations.getByName("relocate") { relocateConfiguration ->
+  if (shadowEnabled.get()) {
+    return
+  }
+
   configurations.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(relocateConfiguration)
   configurations.getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(relocateConfiguration)
 }


### PR DESCRIPTION
Due to the hack in pablo.gradle that extends `relocate` configuration from `implementation`, `asm` was relocated to `paranoid-gradle-plugin` shadow jar twice. This fix disables the hack when publishing dependencies.