### PR TITLE
Fix gradle configuration cache and java tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew -p paranoid publishToMavenLocal -Ppablo.shadow.enabled=true ${{ env.PABLO_OPTS }}
 
       - name: Run unit tests
-        run: ./gradlew check -x lint -Pdevelopment=false
+        run: ./gradlew check -x lint -Pdevelopment=false -Dorg.gradle.unsafe.configuration-cache=true
 
   test:
     name: Test
@@ -67,7 +67,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
-          script: ./gradlew connectedCheck -Pdevelopment=false
+          script: ./gradlew connectedCheck -Pdevelopment=false -Dorg.gradle.unsafe.configuration-cache=true
 
   publish:
     name: Publish

--- a/paranoid/gradle-plugin/src/main/java/com/joom/paranoid/plugin/BackupClassesTask.kt
+++ b/paranoid/gradle-plugin/src/main/java/com/joom/paranoid/plugin/BackupClassesTask.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.paranoid.plugin
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectories
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+abstract class BackupClassesTask : DefaultTask() {
+
+  @InputFiles
+  var classesDirs: List<File> = emptyList()
+
+  @OutputDirectories
+  var backupDirs: List<File> = emptyList()
+
+  @TaskAction
+  fun process() {
+    validate()
+
+    classesDirs.zip(backupDirs) { classesDir, backupDir ->
+      if (!classesDir.exists()) {
+        backupDir.deleteRecursively()
+      } else {
+        copyFiles(classesDir, backupDir)
+      }
+    }
+  }
+
+  private fun copyFiles(classesDir: File, backupDir: File) {
+    backupDir.deleteRecursively()
+    classesDir.copyRecursively(backupDir, overwrite = true)
+  }
+
+  private fun validate() {
+    require(classesDirs.isNotEmpty()) { "classesDirs is not set" }
+    require(backupDirs.isNotEmpty()) { "backupDirs is not set" }
+    require(classesDirs.size == backupDirs.size) { "classesDirs and backupDirs must have equal size" }
+  }
+}

--- a/paranoid/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidTransformTask.kt
+++ b/paranoid/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidTransformTask.kt
@@ -67,6 +67,8 @@ abstract class ParanoidTransformTask : DefaultTask() {
   @Input
   var validateClasspath: Boolean = false
 
+  private val projectName = computeProjectName()
+
   init {
     logging.captureStandardOutput(LogLevel.INFO)
   }
@@ -99,7 +101,7 @@ abstract class ParanoidTransformTask : DefaultTask() {
         bootClasspath = bootClasspath.files,
         validationClasspath = validationClasspath.files,
         validateClasspath = validateClasspath,
-        projectName = (project.path + name.replace(TASK_PREFIX, ":")).replace(':', '$'),
+        projectName = projectName,
       )
 
       processor.process()

--- a/paranoid/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidTransformTask.kt
+++ b/paranoid/gradle-plugin/src/main/java/com/joom/paranoid/plugin/ParanoidTransformTask.kt
@@ -29,8 +29,10 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
 @CacheableTask
 abstract class ParanoidTransformTask : DefaultTask() {
@@ -51,7 +53,12 @@ abstract class ParanoidTransformTask : DefaultTask() {
   abstract val bootClasspath: ConfigurableFileCollection
 
   @get:OutputDirectory
+  @get:Optional
   abstract val output: DirectoryProperty
+
+  @get:OutputDirectories
+  @get:Optional
+  abstract val outputDirectories: ListProperty<File>
 
   @Input
   @Optional
@@ -71,11 +78,23 @@ abstract class ParanoidTransformTask : DefaultTask() {
 
       cleanOutput()
 
+      val outputs = when {
+        output.isPresent -> List(inputClasses.get().size) { output.get().asFile }
+        outputDirectories.isPresent -> outputDirectories.get()
+        else -> error("output or outputDirectories is not set")
+      }
+
+      val genPath = when {
+        output.isPresent -> output.get().asFile
+        outputDirectories.isPresent -> outputDirectories.get().first()
+        else -> error("output or outputDirectories is not set")
+      }
+
       val processor = ParanoidProcessor(
         obfuscationSeed = calculateObfuscationSeed(),
         inputs = inputClasses.get().map { it.asFile },
-        outputs = List(inputClasses.get().size) { output.get().asFile },
-        genPath = output.get().asFile,
+        outputs = outputs,
+        genPath = genPath,
         classpath = classpath.files,
         bootClasspath = bootClasspath.files,
         validationClasspath = validationClasspath.files,
@@ -90,7 +109,13 @@ abstract class ParanoidTransformTask : DefaultTask() {
   }
 
   private fun cleanOutput() {
-    output.get().asFile.deleteRecursively()
+    if (output.isPresent) {
+      output.get().asFile.deleteRecursively()
+    }
+
+    if (outputDirectories.isPresent) {
+      outputDirectories.get().forEach { it.deleteRecursively() }
+    }
   }
 
   private fun calculateObfuscationSeed(): Int {
@@ -103,7 +128,11 @@ abstract class ParanoidTransformTask : DefaultTask() {
 
   private fun validate() {
     require(inputClasses.get().isNotEmpty()) { "inputClasses is not set" }
-    require(output.isPresent) { "output is not set" }
+    require(output.isPresent || outputDirectories.isPresent) { "output is not set" }
+  }
+
+  private fun computeProjectName(): String {
+    return (project.path + name.replace(TASK_PREFIX, ":")).replace(':', '$')
   }
 
   companion object {

--- a/paranoid/processor/src/main/kotlin/com/joom/paranoid/processor/watermark/WatermarkChecker.kt
+++ b/paranoid/processor/src/main/kotlin/com/joom/paranoid/processor/watermark/WatermarkChecker.kt
@@ -16,11 +16,11 @@
 
 package com.joom.paranoid.processor.watermark
 
-import java.io.File
-import java.io.IOException
 import org.objectweb.asm.Attribute
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
+import java.io.File
+import java.io.IOException
 
 class WatermarkChecker(asmApi: Int) : ClassVisitor(asmApi) {
   var isParanoidClass: Boolean = false

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 def isDevelopment = properties['development'].toBoolean()
-includeBuild('paranoid') {
-  if (isDevelopment) {
+if (isDevelopment) {
+  includeBuild('paranoid') {
     dependencySubstitution {
       substitute module('com.joom.paranoid:paranoid-gradle-plugin') using project(':gradle-plugin')
       substitute module('com.joom.paranoid:paranoid-processor') using project(':processor')


### PR DESCRIPTION
This PR fixes incompatible configuration cache usage:

1. Usage of `getProject()` during task execution.
2. Modification of Jar task inputs.

Enabled Gradle configuration cache when executing `check` / `connectedCheck` tasks in GitHub actions.